### PR TITLE
fix: deposit minting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,48 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release/*
+  push:
+    branches:
+      - main
+      - release/*
+
+jobs:
+  build:
+    name: Build
+    timeout-minutes: 20
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version:
+          - 16.13.0
+        os:
+          - ubuntu-20.04
+        experimental: [false]
+    steps:
+      - uses: actions/checkout@v2.3.5
+        with:
+          submodules: true
+      - name: Node ${{ matrix.node_version }} - x64 on ${{ matrix.os }}
+        uses: actions/setup-node@v2.4.1
+        with:
+          node-version: ${{ matrix.node_version }}
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+      - name: Run lint and unit tests
+        run: |
+          npm run lint
+          npm run build
+          npm run test
+          npm run cov

--- a/contracts/DATAv2onPolygon.sol
+++ b/contracts/DATAv2onPolygon.sol
@@ -26,7 +26,9 @@ contract DATAv2onPolygon is DATAv2 {
     function deposit(address user, bytes calldata depositData) external {
         require(_msgSender() == bridgeAddress, "error_onlyBridge");
         uint256 amount = abi.decode(depositData, (uint256));
-        _mint(address(this), amount);
+
+        // emits two Transfer events: 0x0 -> bridgeAddress -> user
+        _mint(bridgeAddress, amount);
         transferAndCall(user, amount, depositData);
     }
 

--- a/test/DATAv2onPolygon-test.js
+++ b/test/DATAv2onPolygon-test.js
@@ -1,0 +1,28 @@
+const { utils: { hexZeroPad, parseEther } } = require("ethers")
+const { expect } = require("chai")
+const { ethers: hardhatEthers } = require("hardhat")
+
+describe("DATAv2onPolygon", () => {
+    it("deposit mints tokens as expected", async () => {
+        const [bridge] = await hardhatEthers.getSigners()
+        const targetUser = "0x1234567890123456789012345678901234567890"
+        const DATAv2onPolygon = await hardhatEthers.getContractFactory("DATAv2onPolygon")
+        const token = await DATAv2onPolygon.deploy(bridge.address)
+        await token.deployed()
+
+        expect((await token.balanceOf(targetUser)).toString()).to.equal("0")
+
+        const amountBytes = hexZeroPad(parseEther("1"), 32)
+        await expect(token.connect(bridge).deposit(targetUser, amountBytes)).to.emit(token, "Transfer(address,address,uint256)")
+
+        expect((await token.balanceOf(targetUser)).toString()).to.equal(parseEther("1").toString())
+    })
+
+    it("only bridge is allowed to deposit", async () => {
+        const [bridge, another] = await hardhatEthers.getSigners()
+        const DATAv2onPolygon = await hardhatEthers.getContractFactory("DATAv2onPolygon")
+        const token = await DATAv2onPolygon.deploy(bridge.address)
+        await token.deployed()
+        await expect(token.connect(another).deposit(another.address, parseEther("1").toHexString())).to.be.revertedWith("error_onlyBridge")
+    })
+})


### PR DESCRIPTION
Bug was in the transfer logic: token contract calling `transferAndCall` on itself will transfer from the `msg.sender` (here, the bridge), not from itself.